### PR TITLE
Prepare 0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+## [0.1.3] - 2025-09-21
+### Changed
+- Expanded the README with feature highlights, usage examples, and workflow tips.
+- Updated the development Ruby version and CI matrix to 3.4.5.
+
+### Fixed
+- Removed the duplicated `combine_blockquotes` helper from `TelegramFormatter` so the shared module remains the single source of truth.
+
 ## [0.1.0] - 2024-07-01
 
 - Initial release

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module ChatGptMdConverter
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end


### PR DESCRIPTION
## Summary
- bump ChatGptMdConverter::VERSION to 0.1.3
- add a 0.1.3 entry to the changelog documenting the latest updates

## Testing
- bundle exec rspec *(fails: bundler cannot install rspec in this environment because Ruby 3.4.5 is required by the Gemfile)*
- bundle install *(fails: Gemfile requires Ruby 3.4.5 but the container provides Ruby 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68d05eec3230832cae14a15249a58a15